### PR TITLE
Jpt 3028 add logging

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,7 @@ module.exports = {
     "src/**/*.ts",
     "!src/ProviderGraphObjectCache.ts",
     "!src/getIterationState.ts",
+    "!src/crowdstrike/pagination.ts",
     "!src/**/index.ts",
     "!src/steps/**/*.ts",
   ],

--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -213,7 +213,7 @@ export class FalconAPIClient {
       seen += response.resources.length;
       total = paginationMeta.total;
       pages += 1;
-      finished = seen >= total;
+      finished = seen === 0 || seen >= total;
     } while (!finished && continuePagination !== false);
 
     const paginationState: PaginationState = {

--- a/src/crowdstrike/pagination.ts
+++ b/src/crowdstrike/pagination.ts
@@ -1,0 +1,28 @@
+/**
+ * The number of resources to request per resource API call (pagination `limit`).
+ */
+export function getPageLimit(name: string, defaultLimit: number): number {
+  return getEnvValue(
+    `CROWDSTRIKE_${name.toUpperCase()}_PAGE_LIMIT`,
+    defaultLimit,
+  );
+}
+
+/**
+ * The number of pages to process per iteration.
+ */
+export function getBatchPages(name: string, defaultLimit: number): number {
+  return getEnvValue(
+    `CROWDSTRIKE_${name.toUpperCase()}_BATCH_PAGES`,
+    defaultLimit,
+  );
+}
+
+function getEnvValue(name: string, defaultValue: number): number {
+  const value = process.env[name];
+  if (value) {
+    return Number(value);
+  } else {
+    return defaultValue;
+  }
+}

--- a/src/steps/fetchDevices.ts
+++ b/src/steps/fetchDevices.ts
@@ -32,7 +32,9 @@ export default {
     const accountEntity = await objectCache.getAccount();
     const deviceIds = (await cache.getEntry("device-ids")).data || [];
 
-    const falconAPI = new FalconAPIClient(executionContext.instance.config);
+    const falconAPI = new FalconAPIClient({
+      credentials: executionContext.instance.config,
+    });
 
     const iterationState = getIterationState(executionContext);
 

--- a/src/steps/fetchPreventionPolicies.ts
+++ b/src/steps/fetchPreventionPolicies.ts
@@ -34,7 +34,9 @@ export default {
     const policyIds =
       (await cache.getEntry("prevention-policy-ids")).data || [];
 
-    const falconAPI = new FalconAPIClient(executionContext.instance.config);
+    const falconAPI = new FalconAPIClient({
+      credentials: executionContext.instance.config,
+    });
 
     const iterationState = getIterationState(executionContext);
 


### PR DESCRIPTION
The goal is to understand why iteration isn't working (it runs forever until the lambda dies).

I started this by refactoring the client to take options instead of fixed params, so that I could pass in a logger. Then I thought it better, as I plan to extract this client from the integration, to make it emit events instead of assuming that we should log stuff. The fetching code then listens for requests and logs the information exposed by the client (not the request entirely). @fomentia just keep this stuff in mind as I'd like to converge on a "client wrapper" that has an interface/behavior (such as emitting a common set of events, iterating resources with callbacks, resumable pagination) which we can reuse with different providers.