### PR TITLE
Add 429 logging to Crowdstrike Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Added logging to Crowdstrike Client for 429 responses

--- a/src/crowdstrike/FalconAPIClient.test.ts
+++ b/src/crowdstrike/FalconAPIClient.test.ts
@@ -1,13 +1,29 @@
+import { IntegrationLogger } from "@jupiterone/jupiter-managed-integration-sdk";
 import { Polly } from "@pollyjs/core";
 
 import polly from "../../test/helpers/polly";
 import config from "../../test/integrationInstanceConfig";
 import { FalconAPIClient } from "./FalconAPIClient";
 
+function createTestLogger(): IntegrationLogger {
+  return {
+    trace: () => undefined,
+    debug: () => undefined,
+    info: () => undefined,
+    warn: () => undefined,
+    error: () => undefined,
+    fatal: () => undefined,
+    child: () => createTestLogger(),
+  };
+}
+
 let p: Polly;
 
 const createClient = (): FalconAPIClient => {
-  return new FalconAPIClient({ credentials: config });
+  return new FalconAPIClient({
+    credentials: config,
+    logger: createTestLogger(),
+  });
 };
 
 afterEach(async () => {
@@ -79,6 +95,7 @@ describe("authenticate", () => {
         ...config,
         clientSecret: "test-error-handling",
       },
+      logger: createTestLogger(),
     });
     try {
       await client.authenticate();
@@ -154,6 +171,7 @@ describe("executeAPIRequest", () => {
       rateLimitConfig: {
         maxAttempts: 2,
       },
+      logger: createTestLogger(),
     });
 
     await expect(client.authenticate()).rejects.toThrowError(/2/);
@@ -190,6 +208,7 @@ describe("executeAPIRequest", () => {
         reserveLimit: 8,
         cooldownPeriod: 1000,
       },
+      logger: createTestLogger(),
     });
 
     const startTime = Date.now();

--- a/src/crowdstrike/createFalconAPIClient.ts
+++ b/src/crowdstrike/createFalconAPIClient.ts
@@ -8,6 +8,7 @@ export default function createFalconAPIClient(
 
   const falconAPI = new FalconAPIClient({
     credentials: instance.config,
+    logger,
   });
 
   falconAPI.events.on(ClientEvents.REQUEST, event => {


### PR DESCRIPTION
We have an integration that's failing with `Could not complete request within ${attempts} attempts!` and need more information to help resolve the issue.