### PR TITLE
Release 2.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.0.4] - 2021-08-30
+
 ### Removed
 
 - Removed event emitter from `FalconAPIClient`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-crowdstrike",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "A template for JupiterOne graph converters.",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
```
## [2.0.4] - 2021-08-30

### Removed

- Removed event emitter from `FalconAPIClient`
- Removed unused pagination parameters from `FalconAPIClient`

### Fixed

- Prevent malformed requests to
  `https://api.crowdstrike.com/devices/entities/devices/v1?` when _no_ devices
  have been found.
