### PR TITLE
Monitor rate limit headers without overwriting

### DIFF
--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -279,15 +279,11 @@ export class FalconAPIClient {
       const response = await request.exec();
 
       rateLimitState = {
-        limitRemaining:
-          Number(response.headers.get('x-ratelimit-remaining')) ||
-          rateLimitState.limitRemaining,
-        perMinuteLimit:
-          Number(response.headers.get('x-ratelimit-limit')) ||
-          rateLimitState.perMinuteLimit,
-        retryAfter: Number(
-          response.headers.get('x-ratelimit-retryafter') || 1000,
-        ),
+        limitRemaining: Number(response.headers.get('X-RateLimit-Remaining')),
+        perMinuteLimit: Number(response.headers.get('X-RateLimit-Limit')),
+        retryAfter:
+          response.headers.get('X-RateLimit-RetryAfter') &&
+          Number(response.headers.get('X-RateLimit-RetryAfter')),
       };
 
       if (response.status !== 429 && response.status !== 500) {
@@ -301,7 +297,9 @@ export class FalconAPIClient {
 
       if (response.status === 429) {
         const epochTimeNow = Date.now() / 1000;
-        const timeToSleepInSeconds = rateLimitState.retryAfter - epochTimeNow;
+        const timeToSleepInSeconds = rateLimitState.retryAfter
+          ? rateLimitState.retryAfter - epochTimeNow
+          : 0;
         this.logger.info(
           {
             epochTimeNow,

--- a/src/crowdstrike/types.ts
+++ b/src/crowdstrike/types.ts
@@ -106,7 +106,7 @@ export type RateLimitState = {
    * The next time when an account's rate limit pool will have at least one
    * request available.
    */
-  retryAfter: number;
+  retryAfter?: number;
 };
 
 /**


### PR DESCRIPTION
If any of the rate limit headers are 0, they're just overwritten with the previous or default `rateLimitState` value. We have no way of knowing whether they are `0` or `null` returned from API.