### PR TITLE
INT-3268 - Prevent duplicate `crowdstrike_vulnerability` entities and relationships

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.1.1] - 2022-04-07
+
+### Fixed
+
+- Prevent duplicate `crowdstrike_vulnerability` entities and relationships from
+  being submitted
+
 ## [2.1.0] - 2022-03-31
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-crowdstrike",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "A template for JupiterOne graph converters.",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
I'm not sure whether this is the ideal fix or not. I've added logging to gather additional information. This data is only toggled on for a single account currently.