### PR TITLE
INT-3520 Add error logging

### DIFF
--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -208,6 +208,17 @@ export class FalconAPIClient {
           },
         });
 
+      if (response.errors?.length) {
+        const errorsToLog = response.errors.map((err) => {
+          return { code: err.code, message: err.message, id: err.id };
+        });
+
+        this.logger.error(
+          { errors: errorsToLog },
+          'encountered error(s) in api response',
+        );
+      }
+
       await callback(response.resources);
 
       this.logger.info(

--- a/src/crowdstrike/types.ts
+++ b/src/crowdstrike/types.ts
@@ -121,6 +121,7 @@ type ResponseMeta = {
 
 type ResponseError = {
   code: number;
+  id: string;
   message: string;
 };
 


### PR DESCRIPTION
# Description

In order to better understand the missing pagination state in some Crowdstrike API responses, we will log errors when we encounter them. This may help us catch errors that occur even when the response is ok.