### PR TITLE
INT-4021 - Fix erroneous relationship deletion

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -71,7 +71,7 @@ export const Relationships: Record<string, StepRelationshipMetadata> = {
     targetType: Entities.PREVENTION_POLICY._type,
   },
   VULN_EXPLOITS_SENSOR: {
-    _type: 'crowdstrike_vuln_exploits_sensor',
+    _type: 'crowdstrike_vulnerability_exploits_sensor',
     sourceType: Entities.VULNERABILITY._type,
     _class: RelationshipClass.EXPLOITS,
     targetType: Entities.SENSOR._type,


### PR DESCRIPTION
- The vuln -> device relationship was being erroneously deleted. The relationship _type was incorrect and therefore the partial flag was not being applied.   Vulns are marked as partial and so should the relationship.