### PR TITLE
fix: query params logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.2.6] - 2022-08-01
+
+### Fixed
+
+- corrected creation of query parameters to only include pagination details at
+  most once and default to using details returned by the CrowdStrike API
+
 ## [2.2.5] - 2022-08-01
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-crowdstrike",
-  "version": "2.2.5",
+  "version": "2.2.6",
   "description": "A template for JupiterOne graph converters.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -501,21 +501,21 @@ function toQueryString(
 ): URLSearchParams {
   const params = new URLSearchParams();
 
-  if (pagination) {
-    if (typeof pagination.limit === 'number') {
-      params.append('limit', String(pagination.limit));
-    }
-    if (pagination.offset !== undefined) {
-      params.append('offset', String(pagination.offset));
-    }
-    if (pagination.after !== undefined) {
-      params.append('after', String(pagination.after));
-    }
-  }
-
   if (queryParams) {
     for (const e of Object.entries(queryParams)) {
       params.append(e[0], String(e[1]));
+    }
+  }
+
+  if (pagination) {
+    if (typeof pagination.limit === 'number') {
+      params.set('limit', String(pagination.limit));
+    }
+    if (pagination.offset !== undefined) {
+      params.set('offset', String(pagination.offset));
+    }
+    if (pagination.after !== undefined) {
+      params.set('after', String(pagination.after));
     }
   }
 

--- a/src/steps/fetchDevices.ts
+++ b/src/steps/fetchDevices.ts
@@ -21,7 +21,6 @@ export async function fetchDevices(
   logger.info('Iterating devices...');
   await client.iterateDevices({
     query: {
-      limit: '250',
       filter: `last_seen:>='${lastSeenSince()}'`,
     },
     callback: async (devices) => {


### PR DESCRIPTION
# Description

This PR changes logic for the creation of query params. For paramaters dealing with pagination,
these shouldn't be set more than once. We should also default to using the paramters returned by
the response if they are available.
