### PR TITLE
Add Timestamp Filter Utility

### DIFF
--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -124,11 +124,11 @@ export class FalconAPIClient {
    * @returns Promise
    */
   public async iterateVulnerabilities(input: {
-    callBack: FalconAPIResourceIterationCallback<Vulnerability>;
+    callback: FalconAPIResourceIterationCallback<Vulnerability>;
     query?: QueryParams;
   }): Promise<void> {
     return this.paginateResources<Vulnerability>({
-      callback: input.callBack,
+      callback: input.callback,
       query: input.query,
       resourcePath: '/spotlight/combined/vulnerabilities/v1',
     });

--- a/src/jupiterone/converters.ts
+++ b/src/jupiterone/converters.ts
@@ -1,7 +1,6 @@
 import {
   convertProperties,
   createIntegrationEntity,
-  getTime,
   parseTimePropertyValue,
 } from '@jupiterone/integration-sdk-core';
 import { Entities } from '../steps/constants';
@@ -95,8 +94,8 @@ export function createSensorAgentEntity(source: Device) {
         _key: source.device_id,
         name: source.hostname,
         function: ['anti-malware', 'activity-monitor'],
-        firstSeenOn: getTime(source.first_seen),
-        lastSeenOn: getTime(source.last_seen),
+        firstSeenOn: parseTimePropertyValue(source.first_seen),
+        lastSeenOn: parseTimePropertyValue(source.last_seen),
         active: source.status === 'normal',
 
         // CrowdStrike formats their MAC addresses in dash-separated form. We

--- a/src/steps/account/index.ts
+++ b/src/steps/account/index.ts
@@ -11,10 +11,10 @@ import {
 } from '../../jupiterone/converters';
 import { IntegrationConfig } from '../../config';
 
-async function getAccount(
-  context: IntegrationStepExecutionContext<IntegrationConfig>,
-): Promise<void> {
-  const { instance, jobState } = context;
+async function getAccount({
+  instance,
+  jobState,
+}: IntegrationStepExecutionContext<IntegrationConfig>): Promise<void> {
   const accountEntity = await jobState.addEntity(createAccountEntity(instance));
   await jobState.setData(SetDataKeys.ACCOUNT_ENTITY, accountEntity);
 

--- a/src/steps/devicePolicies/index.ts
+++ b/src/steps/devicePolicies/index.ts
@@ -9,10 +9,11 @@ import getOrCreateFalconAPIClient from '../../crowdstrike/getOrCreateFalconAPICl
 import { PreventionPolicy } from '../../crowdstrike/types';
 import { IntegrationConfig } from '../../config';
 
-async function fetchDevicePolicyRelationships(
-  context: IntegrationStepExecutionContext<IntegrationConfig>,
-): Promise<void> {
-  const { instance, jobState, logger } = context;
+async function fetchDevicePolicyRelationships({
+  instance,
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<IntegrationConfig>): Promise<void> {
   const client = getOrCreateFalconAPIClient(instance.config, logger);
 
   logger.info('Iterating policy members...');

--- a/src/steps/preventionPolicies/index.ts
+++ b/src/steps/preventionPolicies/index.ts
@@ -8,13 +8,13 @@ import { Entities, Relationships, StepIds } from '../constants';
 import getOrCreateFalconAPIClient from '../../crowdstrike/getOrCreateFalconAPIClient';
 import { createPreventionPolicyEntity } from '../../jupiterone/converters';
 import { IntegrationConfig } from '../../config';
-import { getProtectionServiceEntityFromJobState } from '../utils';
+import { getProtectionServiceEntityFromJobState } from '../util';
 
-async function fetchPreventionPolicies(
-  context: IntegrationStepExecutionContext<IntegrationConfig>,
-): Promise<void> {
-  const { instance, jobState, logger } = context;
-
+async function fetchPreventionPolicies({
+  instance,
+  jobState,
+  logger,
+}: IntegrationStepExecutionContext<IntegrationConfig>): Promise<void> {
   const protectionServiceEntity = await getProtectionServiceEntityFromJobState(
     jobState,
   );

--- a/src/steps/util.ts
+++ b/src/steps/util.ts
@@ -39,6 +39,11 @@ export async function getProtectionServiceEntityFromJobState(
 
 const DAY_IN_MS = 1000 * 60 * 60 * 24;
 
+/**
+ * getDateInPast returns a date in the past by the number of days specified.
+ * @param daysAgo {number} - number of days in the past
+ * @returns {Date} - date in the past
+ */
 export function getDateInPast(daysAgo: number): Date {
   return new Date(Date.now() - daysAgo * DAY_IN_MS);
 }

--- a/src/steps/util.ts
+++ b/src/steps/util.ts
@@ -36,3 +36,13 @@ export async function getProtectionServiceEntityFromJobState(
   }
   return protectionServiceEntity;
 }
+
+const DAY_IN_MS = 1000 * 60 * 60 * 24;
+
+export function getDateInPast(daysAgo: number): Date {
+  return new Date(Date.now() - daysAgo * DAY_IN_MS);
+}
+
+export function createFQLTimestamp(date: Date) {
+  return date.toISOString();
+}

--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -13,6 +13,11 @@ import { IntegrationWarnEventName } from '@jupiterone/integration-sdk-core/dist/
 import { createFQLTimestamp } from '../util';
 import { calculateCreatedFilterTime } from './util';
 
+// maxDaysInPast is set to 10 days because most integrations will run at least once a week.
+// Additionally, at the time of this comment, we are just using the `created_timestamp`
+// as a filter, so the quantity of data can still be extremely large.
+const maxDaysInPast = 10;
+
 async function fetchVulnerabilities({
   instance,
   jobState,
@@ -23,7 +28,7 @@ async function fetchVulnerabilities({
   const lastSuccessfulRun = executionHistory.lastSuccessful?.startedOn;
 
   const createdTimestampFilter = createFQLTimestamp(
-    calculateCreatedFilterTime({ maxDaysInPast: 10, lastSuccessfulRun }),
+    calculateCreatedFilterTime({ maxDaysInPast, lastSuccessfulRun }),
   );
 
   let duplicateVulnerabilityKeysFoundCount = 0;

--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -10,40 +10,36 @@ import getOrCreateFalconAPIClient from '../../crowdstrike/getOrCreateFalconAPICl
 import { Entities, Relationships, StepIds } from '../constants';
 import { createVulnerabilityEntity } from '../../jupiterone/converters';
 import { IntegrationWarnEventName } from '@jupiterone/integration-sdk-core/dist/src/types/logger';
+import { createCreatedTimestampFilter } from './util';
 
-// TODO: Understand the amount of data to be ingested by looking back only 10 days
-// const THIRTY_DAYS_AGO = 30 * 24 * 60 * 60 * 1000;
-const TEN_DAYS_AGO = 10 * 24 * 60 * 60 * 1000;
-
-async function fetchVulnerabilities(
-  context: IntegrationStepExecutionContext<IntegrationConfig>,
-): Promise<void> {
-  const { instance, jobState, logger } = context;
-
+async function fetchVulnerabilities({
+  instance,
+  jobState,
+  logger,
+  executionHistory,
+}: IntegrationStepExecutionContext<IntegrationConfig>): Promise<void> {
   const client = getOrCreateFalconAPIClient(instance.config, logger);
-  const lastSuccessfulSyncTime =
-    context.executionHistory.lastSuccessful?.startedOn;
+  const lastSuccessfulRun = executionHistory.lastSuccessful?.startedOn;
 
-  const daysAgo = Date.now() - TEN_DAYS_AGO;
-
-  const createdTimestampFilter = new Date(
-    lastSuccessfulSyncTime ?? daysAgo,
-  ).toISOString();
-
-  logger.info('Iterating vulnerabilities...');
+  const createdTimestampFilter = createCreatedTimestampFilter({
+    maxDaysInPast: 10,
+    lastSuccessfulRun,
+  });
 
   let duplicateVulnerabilityKeysFoundCount = 0;
   let duplicateVulnerabilitySensorRelationshipKeysFoundCount = 0;
   let sensorEntitiesNotFoundCount = 0;
 
+  const filter = `created_timestamp:>${createdTimestampFilter}`;
+
   await client
     .iterateVulnerabilities({
       query: {
         limit: '250',
-        filter: `created_timestamp:>'${createdTimestampFilter}'`,
+        filter,
         sort: `created_timestamp|desc`,
       },
-      callBack: async (vulns) => {
+      callback: async (vulns) => {
         logger.info(
           { vulnerabilityCount: vulns.length, createdTimestampFilter },
           'Creating vulnerability entities and relationships...',

--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -10,7 +10,8 @@ import getOrCreateFalconAPIClient from '../../crowdstrike/getOrCreateFalconAPICl
 import { Entities, Relationships, StepIds } from '../constants';
 import { createVulnerabilityEntity } from '../../jupiterone/converters';
 import { IntegrationWarnEventName } from '@jupiterone/integration-sdk-core/dist/src/types/logger';
-import { createCreatedTimestampFilter } from './util';
+import { createFQLTimestamp } from '../util';
+import { calculateCreatedFilterTime } from './util';
 
 async function fetchVulnerabilities({
   instance,
@@ -21,10 +22,9 @@ async function fetchVulnerabilities({
   const client = getOrCreateFalconAPIClient(instance.config, logger);
   const lastSuccessfulRun = executionHistory.lastSuccessful?.startedOn;
 
-  const createdTimestampFilter = createCreatedTimestampFilter({
-    maxDaysInPast: 10,
-    lastSuccessfulRun,
-  });
+  const createdTimestampFilter = createFQLTimestamp(
+    calculateCreatedFilterTime({ maxDaysInPast: 10, lastSuccessfulRun }),
+  );
 
   let duplicateVulnerabilityKeysFoundCount = 0;
   let duplicateVulnerabilitySensorRelationshipKeysFoundCount = 0;

--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -30,7 +30,7 @@ async function fetchVulnerabilities({
   let duplicateVulnerabilitySensorRelationshipKeysFoundCount = 0;
   let sensorEntitiesNotFoundCount = 0;
 
-  const filter = `created_timestamp:>${createdTimestampFilter}`;
+  const filter = `created_timestamp:>'${createdTimestampFilter}'`;
 
   await client
     .iterateVulnerabilities({

--- a/src/steps/vulnerabilities/util.test.ts
+++ b/src/steps/vulnerabilities/util.test.ts
@@ -1,7 +1,49 @@
+import { getDateInPast } from '../util';
+import { calculateFilterTime } from './util';
+
+function mockDateNow() {
+  return 1659689855416;
+}
+
 describe('calculateFilterTime', () => {
-  test('should return maxDaysInPast as Date if lastSuccessfulRun is undefined', () => {});
+  let originalDateNow: () => number;
+  beforeEach(() => {
+    originalDateNow = Date.now;
+    Date.now = mockDateNow;
+  });
 
-  test('should never return a date greater than maxDaysInPast', () => {});
+  afterEach(() => {
+    Date.now = originalDateNow;
+  });
 
-  test('should return lastSuccessfulRun if less than maxDaysInPast', () => {});
+  test('should return maxDaysInPast as Date if lastSuccessfulRun is undefined', () => {
+    const data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    for (const d of data) {
+      const expected = getDateInPast(d).getTime();
+      const actual = calculateFilterTime({ maxDaysInPast: d }).getTime();
+      expect(actual).toBe(expected);
+    }
+  });
+
+  test('should never return a date greater than maxDaysInPast', () => {
+    const daysInPast = 1;
+    const expected = getDateInPast(daysInPast).getTime();
+    const lastSuccessfulRuns = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    for (const runs of lastSuccessfulRuns) {
+      const actual = calculateFilterTime({
+        maxDaysInPast: daysInPast,
+        lastSuccessfulRun: runs,
+      }).getTime();
+      expect(actual).toBeLessThanOrEqual(expected);
+    }
+  });
+
+  test('should return lastSuccessfulRun if less than maxDaysInPast', () => {
+    const lastSuccessfulRun = getDateInPast(9).getTime();
+    const actual = calculateFilterTime({
+      maxDaysInPast: 10,
+      lastSuccessfulRun,
+    }).getTime();
+    expect(actual).toBe(lastSuccessfulRun);
+  });
 });

--- a/src/steps/vulnerabilities/util.test.ts
+++ b/src/steps/vulnerabilities/util.test.ts
@@ -1,11 +1,11 @@
 import { getDateInPast } from '../util';
-import { calculateFilterTime } from './util';
+import { calculateCreatedFilterTime } from './util';
 
 function mockDateNow() {
   return 1659689855416;
 }
 
-describe('calculateFilterTime', () => {
+describe('calculateCreatedFilterTime', () => {
   let originalDateNow: () => number;
   beforeEach(() => {
     originalDateNow = Date.now;
@@ -20,7 +20,7 @@ describe('calculateFilterTime', () => {
     const data = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     for (const d of data) {
       const expected = getDateInPast(d).getTime();
-      const actual = calculateFilterTime({ maxDaysInPast: d }).getTime();
+      const actual = calculateCreatedFilterTime({ maxDaysInPast: d }).getTime();
       expect(actual).toBe(expected);
     }
   });
@@ -30,7 +30,7 @@ describe('calculateFilterTime', () => {
     const expected = getDateInPast(daysInPast).getTime();
     const lastSuccessfulRuns = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     for (const runs of lastSuccessfulRuns) {
-      const actual = calculateFilterTime({
+      const actual = calculateCreatedFilterTime({
         maxDaysInPast: daysInPast,
         lastSuccessfulRun: runs,
       }).getTime();
@@ -40,7 +40,7 @@ describe('calculateFilterTime', () => {
 
   test('should return lastSuccessfulRun if less than maxDaysInPast', () => {
     const lastSuccessfulRun = getDateInPast(9).getTime();
-    const actual = calculateFilterTime({
+    const actual = calculateCreatedFilterTime({
       maxDaysInPast: 10,
       lastSuccessfulRun,
     }).getTime();

--- a/src/steps/vulnerabilities/util.test.ts
+++ b/src/steps/vulnerabilities/util.test.ts
@@ -1,0 +1,7 @@
+describe('calculateFilterTime', () => {
+  test('should return maxDaysInPast as Date if lastSuccessfulRun is undefined', () => {});
+
+  test('should never return a date greater than maxDaysInPast', () => {});
+
+  test('should return lastSuccessfulRun if less than maxDaysInPast', () => {});
+});

--- a/src/steps/vulnerabilities/util.ts
+++ b/src/steps/vulnerabilities/util.ts
@@ -1,0 +1,34 @@
+import { getDateInPast } from '../util';
+
+type CreateFilterTimeParams = {
+  maxDaysInPast: number;
+  lastSuccessfulRun?: number;
+};
+
+export function createCreatedTimestampFilter({
+  maxDaysInPast,
+  lastSuccessfulRun,
+}: CreateFilterTimeParams): string {
+  const filterTime = calculateFilterTime({
+    maxDaysInPast,
+    lastSuccessfulRun,
+  }).toISOString();
+
+  return filterTime;
+}
+
+export function calculateFilterTime({
+  maxDaysInPast,
+  lastSuccessfulRun,
+}: CreateFilterTimeParams): Date {
+  if (!lastSuccessfulRun) {
+    return getDateInPast(maxDaysInPast);
+  }
+
+  const dateInPast = getDateInPast(maxDaysInPast);
+  if (dateInPast.getTime() > lastSuccessfulRun) {
+    return dateInPast;
+  } else {
+    return new Date(lastSuccessfulRun);
+  }
+}

--- a/src/steps/vulnerabilities/util.ts
+++ b/src/steps/vulnerabilities/util.ts
@@ -5,6 +5,10 @@ type CalculateCreatedFilterTimeParams = {
   lastSuccessfulRun?: number;
 };
 
+/**
+ * calculateCreatedFilterTime calculates the Date to use to filter
+ * based on the last successful run and a maximum number of days in the past.
+ */
 export function calculateCreatedFilterTime({
   maxDaysInPast,
   lastSuccessfulRun,

--- a/src/steps/vulnerabilities/util.ts
+++ b/src/steps/vulnerabilities/util.ts
@@ -21,13 +21,13 @@ export function calculateFilterTime({
   maxDaysInPast,
   lastSuccessfulRun,
 }: CreateFilterTimeParams): Date {
+  const maxDateInPast = getDateInPast(maxDaysInPast);
   if (!lastSuccessfulRun) {
-    return getDateInPast(maxDaysInPast);
+    return maxDateInPast;
   }
 
-  const dateInPast = getDateInPast(maxDaysInPast);
-  if (dateInPast.getTime() > lastSuccessfulRun) {
-    return dateInPast;
+  if (maxDateInPast.getTime() > lastSuccessfulRun) {
+    return maxDateInPast;
   } else {
     return new Date(lastSuccessfulRun);
   }

--- a/src/steps/vulnerabilities/util.ts
+++ b/src/steps/vulnerabilities/util.ts
@@ -1,26 +1,14 @@
 import { getDateInPast } from '../util';
 
-type CreateFilterTimeParams = {
+type CalculateCreatedFilterTimeParams = {
   maxDaysInPast: number;
   lastSuccessfulRun?: number;
 };
 
-export function createCreatedTimestampFilter({
+export function calculateCreatedFilterTime({
   maxDaysInPast,
   lastSuccessfulRun,
-}: CreateFilterTimeParams): string {
-  const filterTime = calculateFilterTime({
-    maxDaysInPast,
-    lastSuccessfulRun,
-  }).toISOString();
-
-  return filterTime;
-}
-
-export function calculateFilterTime({
-  maxDaysInPast,
-  lastSuccessfulRun,
-}: CreateFilterTimeParams): Date {
+}: CalculateCreatedFilterTimeParams): Date {
   const maxDateInPast = getDateInPast(maxDaysInPast);
   if (!lastSuccessfulRun) {
     return maxDateInPast;


### PR DESCRIPTION
# Description

This PR introduces utilities for calculating a timestamp for use in filtering using the Falcon Query Language.

Various other small code style changes are included + a change to `parseTimePropertyValue` for properties previously using `getTime`.