### PR TITLE
Int 4887 ingest hidden devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ dist/
 .env
 .eslintcache
 tsconfig.tsbuildinfo
+.DS_Store
+yarn-error.log

--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -108,11 +108,36 @@ export class FalconAPIClient {
       callback: async (deviceIds) => {
         if (deviceIds.length) {
           // If the scroll lists _no_ recent devices, we don't want to send a malformed request to https://api.crowdstrike.com/devices/entities/devices/v1?
-          return await input.callback(await this.fetchDevices(deviceIds));
+          return input.callback(await this.fetchDevices(deviceIds));
         }
       },
       query: input.query,
       resourcePath: '/devices/queries/devices-scroll/v1',
+    });
+  }
+
+  /**
+   * Iterates through hidden devices.
+   Beta - Docs are unclear how hidden devices are different than devices.   * @param input
+   */
+  public async iterateHiddenDevices(input: {
+    callback: FalconAPIResourceIterationCallback<Device>;
+    query?: QueryParams;
+  }): Promise<void> {
+    return this.paginateResources<DeviceIdentifier>({
+      callback: async (deviceIds) => {
+        if (deviceIds.length) {
+          this.logger.info(
+            { hiddenDevicesCount: deviceIds.length },
+            `Found hidden devices.`,
+          );
+
+          // If the scroll lists _no_ recent devices, we don't want to send a malformed request to https://api.crowdstrike.com/devices/entities/devices/v1?
+          return input.callback(await this.fetchDevices(deviceIds));
+        }
+      },
+      query: input.query,
+      resourcePath: '/devices/queries/devices-hidden/v1',
     });
   }
 

--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -118,7 +118,8 @@ export class FalconAPIClient {
 
   /**
    * Iterates through hidden devices.
-   Beta - Docs are unclear how hidden devices are different than devices.   * @param input
+   * Beta - Docs are unclear how hidden devices are different than devices.
+   * @param input
    */
   public async iterateHiddenDevices(input: {
     callback: FalconAPIResourceIterationCallback<Device>;

--- a/src/steps/devices/index.ts
+++ b/src/steps/devices/index.ts
@@ -57,32 +57,34 @@ async function fetchDevices({
     '2a04aebf-04ad-4649-bf8f-73abe00c81b0',
   ].includes(instance.accountId);
 
-  if (enableHiddenDevices) logger.info('Iterating hidden devices...');
+  if (enableHiddenDevices) {
+    logger.info('Iterating hidden devices...');
 
-  await client.iterateHiddenDevices({
-    query: {
-      filter: `last_seen:>='${timestamp}'`,
-    },
-    callback: async (devices) => {
-      logger.info(
-        { deviceCount: devices.length },
-        'Creating device entities and relationships (hidden)...',
-      );
+    await client.iterateHiddenDevices({
+      query: {
+        filter: `last_seen:>='${timestamp}'`,
+      },
+      callback: async (devices) => {
+        logger.info(
+          { deviceCount: devices.length },
+          'Creating device entities and relationships (hidden)...',
+        );
 
-      for (const device of devices) {
-        const deviceEntity = await jobState.addEntity(
-          createSensorAgentEntity(device),
-        );
-        await jobState.addRelationship(
-          createDirectRelationship({
-            from: accountEntity,
-            _class: RelationshipClass.HAS,
-            to: deviceEntity,
-          }),
-        );
-      }
-    },
-  });
+        for (const device of devices) {
+          const deviceEntity = await jobState.addEntity(
+            createSensorAgentEntity(device),
+          );
+          await jobState.addRelationship(
+            createDirectRelationship({
+              from: accountEntity,
+              _class: RelationshipClass.HAS,
+              to: deviceEntity,
+            }),
+          );
+        }
+      },
+    });
+  }
 }
 
 export const devicesSteps: IntegrationStep<IntegrationConfig>[] = [

--- a/src/steps/devices/index.ts
+++ b/src/steps/devices/index.ts
@@ -57,31 +57,32 @@ async function fetchDevices({
     '2a04aebf-04ad-4649-bf8f-73abe00c81b0',
   ].includes(instance.accountId);
 
-  if (enableHiddenDevices)
-    await client.iterateHiddenDevices({
-      query: {
-        filter: `last_seen:>='${timestamp}'`,
-      },
-      callback: async (devices) => {
-        logger.info(
-          { deviceCount: devices.length },
-          'Creating device entities and relationships (hidden)...',
-        );
+  if (enableHiddenDevices) logger.info('Iterating hidden devices...');
 
-        for (const device of devices) {
-          const deviceEntity = await jobState.addEntity(
-            createSensorAgentEntity(device),
-          );
-          await jobState.addRelationship(
-            createDirectRelationship({
-              from: accountEntity,
-              _class: RelationshipClass.HAS,
-              to: deviceEntity,
-            }),
-          );
-        }
-      },
-    });
+  await client.iterateHiddenDevices({
+    query: {
+      filter: `last_seen:>='${timestamp}'`,
+    },
+    callback: async (devices) => {
+      logger.info(
+        { deviceCount: devices.length },
+        'Creating device entities and relationships (hidden)...',
+      );
+
+      for (const device of devices) {
+        const deviceEntity = await jobState.addEntity(
+          createSensorAgentEntity(device),
+        );
+        await jobState.addRelationship(
+          createDirectRelationship({
+            from: accountEntity,
+            _class: RelationshipClass.HAS,
+            to: deviceEntity,
+          }),
+        );
+      }
+    },
+  });
 }
 
 export const devicesSteps: IntegrationStep<IntegrationConfig>[] = [

--- a/src/steps/devices/index.ts
+++ b/src/steps/devices/index.ts
@@ -50,6 +50,32 @@ async function fetchDevices({
       }
     },
   });
+
+  // Attempt to collect missing devices.
+  await client.iterateHiddenDevices({
+    query: {
+      filter: `last_seen:>='${timestamp}'`,
+    },
+    callback: async (devices) => {
+      logger.info(
+        { deviceCount: devices.length },
+        'Creating device entities and relationships (hidden)...',
+      );
+
+      for (const device of devices) {
+        const deviceEntity = await jobState.addEntity(
+          createSensorAgentEntity(device),
+        );
+        await jobState.addRelationship(
+          createDirectRelationship({
+            from: accountEntity,
+            _class: RelationshipClass.HAS,
+            to: deviceEntity,
+          }),
+        );
+      }
+    },
+  });
 }
 
 export const devicesSteps: IntegrationStep<IntegrationConfig>[] = [

--- a/src/steps/devices/index.ts
+++ b/src/steps/devices/index.ts
@@ -51,10 +51,10 @@ async function fetchDevices({
     },
   });
 
-  // Attempt to collect missing devices in Indeed, Inc's account
+  // Attempt to collect missing devices
   const enableHiddenDevices = [
     'j1dev',
-    '2a04aebf-04ad-4649-bf8f-73abe00c81b0',
+    '2a04aebf-04ad-4649-bf8f-73abe00c81b0', //Indeed, Inc
   ].includes(instance.accountId);
 
   if (enableHiddenDevices) {


### PR DESCRIPTION
Indeed has suggested that there are missing devices when comparing Crowdstrike to J1.

While looking around, I discovered this endpoint. These changes are an attempt to learn more about this endpoint. Very little is documented. No data is returned from our test account.

I've asked Tony to see if Indeed is okay with testing this endpoint out.