### PR TITLE
Updating documentation around crowdstrike_sensor ingestion

### DIFF
--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -23,7 +23,9 @@
 ## Support
 
 The query used to ingest vulnerabilities limits to the date/time of the last
-successful integration or to the last 30 days for the initial run.
+successful integration or to the last 30 days for the initial run. Similarly,
+only crowdstrike_sensors seen by CrowdStrike in the last 30 days will be
+ingested.
 
 If you need help with this integration, please contact
 [JupiterOne Support](https://support.jupiterone.io).

--- a/src/jupiterone/converters.ts
+++ b/src/jupiterone/converters.ts
@@ -95,6 +95,11 @@ export function createSensorAgentEntity(source: Device) {
         ...convertProperties(source),
         _class: Entities.SENSOR._class,
         _type: Entities.SENSOR._type,
+
+        // Crowdstrike's device ID for sensors will change when the sensor
+        // version is upgraded.  This is listed in their API documentation
+        // and it notes that this means that it's a valid case for a Host to
+        // potentially have multiple sensors protecting it.
         _key: source.device_id,
         name: source.hostname,
         function: ['anti-malware', 'activity-monitor'],


### PR DESCRIPTION
- Updating documentation to note that only sensors seen in the last 30 days will be ingested.  
- Adding comment in code about how device IDs will change when upgraded.