### PR TITLE
INT-6356 - Make connection between apps and vulns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,15 @@ and this project adheres to
 
 The following entity is **now** created:
 
-| Resources   | Entity `_type`            | Entity `_class` |
-| ----------- | ------------------------- | --------------- |
-| Application | `crowdstrike_application` | `Application`   |
+| Resources   | Entity `_type`                     | Entity `_class` |
+| ----------- | ---------------------------------- | --------------- |
+| Application | `crowdstrike_detected_application` | `Application`   |
 
 The following relationship is **now** created:
 
-| Source Entity `_type`     | Relationship `_class` | Target Entity `_type`       |
-| ------------------------- | --------------------- | --------------------------- |
-| `crowdstrike_application` | **HAS**               | `crowdstrike_vulnerability` |
+| Source Entity `_type`              | Relationship `_class` | Target Entity `_type`       |
+| ---------------------------------- | --------------------- | --------------------------- |
+| `crowdstrike_detected_application` | **HAS**               | `crowdstrike_vulnerability` |
 
 ## [3.1.2] - 2022-01-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,27 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+The following entity is **now** created:
+
+| Resources   | Entity `_type`            | Entity `_class` |
+| ----------- | ------------------------- | --------------- |
+| Application | `crowdstrike_application` | `Application`   |
+
+The following relationship is **now** created:
+
+| Source Entity `_type`     | Relationship `_class` | Target Entity `_type`       |
+| ------------------------- | --------------------- | --------------------------- |
+| `crowdstrike_application` | **HAS**               | `crowdstrike_vulnerability` |
+
 ## [3.1.2] - 2022-01-05
 
 ### Changed
 
 - Collection period for devices extended to 50 days from 30.
 
-### Added
+## Added
 
 - Added config properties for `vulnerabilitiesLimit` and `devicesLimit`.
 

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -96,27 +96,27 @@ https://github.com/JupiterOne/sdk/blob/main/docs/integrations/development.md
 
 The following entities are created:
 
-| Resources           | Entity `_type`                    | Entity `_class` |
-| ------------------- | --------------------------------- | --------------- |
-| Account             | `crowdstrike_account`             | `Account`       |
-| Application         | `crowdstrike_application`         | `Application`   |
-| Device Sensor Agent | `crowdstrike_sensor`              | `HostAgent`     |
-| Prevention Policy   | `crowdstrike_prevention_policy`   | `ControlPolicy` |
-| Service             | `crowdstrike_endpoint_protection` | `Service`       |
-| Vulnerability       | `crowdstrike_vulnerability`       | `Finding`       |
+| Resources           | Entity `_type`                     | Entity `_class` |
+| ------------------- | ---------------------------------- | --------------- |
+| Account             | `crowdstrike_account`              | `Account`       |
+| Application         | `crowdstrike_detected_application` | `Application`   |
+| Device Sensor Agent | `crowdstrike_sensor`               | `HostAgent`     |
+| Prevention Policy   | `crowdstrike_prevention_policy`    | `ControlPolicy` |
+| Service             | `crowdstrike_endpoint_protection`  | `Service`       |
+| Vulnerability       | `crowdstrike_vulnerability`        | `Finding`       |
 
 ### Relationships
 
 The following relationships are created:
 
-| Source Entity `_type`           | Relationship `_class` | Target Entity `_type`             |
-| ------------------------------- | --------------------- | --------------------------------- |
-| `crowdstrike_account`           | **HAS**               | `crowdstrike_endpoint_protection` |
-| `crowdstrike_account`           | **HAS**               | `crowdstrike_sensor`              |
-| `crowdstrike_application`       | **HAS**               | `crowdstrike_vulnerability`       |
-| `crowdstrike_prevention_policy` | **ENFORCES**          | `crowdstrike_endpoint_protection` |
-| `crowdstrike_sensor`            | **ASSIGNED**          | `crowdstrike_prevention_policy`   |
-| `crowdstrike_vulnerability`     | **EXPLOITS**          | `crowdstrike_sensor`              |
+| Source Entity `_type`              | Relationship `_class` | Target Entity `_type`             |
+| ---------------------------------- | --------------------- | --------------------------------- |
+| `crowdstrike_account`              | **HAS**               | `crowdstrike_endpoint_protection` |
+| `crowdstrike_account`              | **HAS**               | `crowdstrike_sensor`              |
+| `crowdstrike_detected_application` | **HAS**               | `crowdstrike_vulnerability`       |
+| `crowdstrike_prevention_policy`    | **ENFORCES**          | `crowdstrike_endpoint_protection` |
+| `crowdstrike_sensor`               | **ASSIGNED**          | `crowdstrike_prevention_policy`   |
+| `crowdstrike_vulnerability`        | **EXPLOITS**          | `crowdstrike_sensor`              |
 
 <!--
 ********************************************************************************

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -99,6 +99,7 @@ The following entities are created:
 | Resources           | Entity `_type`                    | Entity `_class` |
 | ------------------- | --------------------------------- | --------------- |
 | Account             | `crowdstrike_account`             | `Account`       |
+| Application         | `crowdstrike_application`         | `Application`   |
 | Device Sensor Agent | `crowdstrike_sensor`              | `HostAgent`     |
 | Prevention Policy   | `crowdstrike_prevention_policy`   | `ControlPolicy` |
 | Service             | `crowdstrike_endpoint_protection` | `Service`       |
@@ -112,6 +113,7 @@ The following relationships are created:
 | ------------------------------- | --------------------- | --------------------------------- |
 | `crowdstrike_account`           | **HAS**               | `crowdstrike_endpoint_protection` |
 | `crowdstrike_account`           | **HAS**               | `crowdstrike_sensor`              |
+| `crowdstrike_application`       | **HAS**               | `crowdstrike_vulnerability`       |
 | `crowdstrike_prevention_policy` | **ENFORCES**          | `crowdstrike_endpoint_protection` |
 | `crowdstrike_sensor`            | **ASSIGNED**          | `crowdstrike_prevention_policy`   |
 | `crowdstrike_vulnerability`     | **EXPLOITS**          | `crowdstrike_sensor`              |

--- a/src/crowdstrike/types.ts
+++ b/src/crowdstrike/types.ts
@@ -186,14 +186,16 @@ export type Vulnerability = {
     site_name: string;
     system_manufacturer: string;
   };
-  apps?: {
-    product_name_version: string;
-    sub_status: string;
-    remediation?: {
-      ids: string[];
-    };
-    evaluation_logic: {
-      id: string;
-    };
-  }[];
+  apps?: Application[];
+};
+
+export type Application = {
+  product_name_version: string;
+  sub_status: string;
+  remediation?: {
+    ids: string[];
+  };
+  evaluation_logic: {
+    id: string;
+  };
 };

--- a/src/jupiterone/converters.test.ts
+++ b/src/jupiterone/converters.test.ts
@@ -6,13 +6,19 @@ import {
 
 import { createMockExecutionContext } from '@jupiterone/integration-sdk-testing';
 
-import { Device, PreventionPolicy, Vulnerability } from '../crowdstrike/types';
+import {
+  Application,
+  Device,
+  PreventionPolicy,
+  Vulnerability,
+} from '../crowdstrike/types';
 import {
   createAccountEntity,
   createSensorAgentEntity,
   createPreventionPolicyEntity,
   createProtectionServiceEntity,
   createVulnerabilityEntity,
+  createApplicationEntity,
 } from './converters';
 
 describe('createAccountEntity', () => {
@@ -386,6 +392,48 @@ describe('createVulnerabilityEntity', () => {
       webLink: 'alink',
       exploitStatus: 0,
       exprtRating: 'MEDIUM',
+    });
+  });
+});
+
+describe('createApplicationEntity', () => {
+  test('properties transferred', () => {
+    const source: Application = {
+      product_name_version: 'Windows Server 2016 1607',
+      sub_status: 'open',
+      remediation: {
+        ids: ['9497362a882d3be38b4505cbb9aa1e21'],
+      },
+      evaluation_logic: {
+        id: 'eae54d591fe733398ac4aaa4652c8624',
+      },
+    };
+
+    expect(createApplicationEntity(source)).toEqual({
+      _class: ['Application'],
+      _key: 'windows-server-2016-1607',
+      _rawData: [
+        {
+          name: 'default',
+          rawData: {
+            product_name_version: 'Windows Server 2016 1607',
+            sub_status: 'open',
+            remediation: {
+              ids: ['9497362a882d3be38b4505cbb9aa1e21'],
+            },
+            evaluation_logic: {
+              id: 'eae54d591fe733398ac4aaa4652c8624',
+            },
+          },
+        },
+      ],
+      _type: 'crowdstrike_application',
+      name: 'Windows Server 2016 1607',
+      displayName: 'Windows Server 2016 1607',
+      createdOn: undefined,
+      open: true,
+      remediationIds: ['9497362a882d3be38b4505cbb9aa1e21'],
+      evaluationLogicId: 'eae54d591fe733398ac4aaa4652c8624',
     });
   });
 });

--- a/src/jupiterone/converters.test.ts
+++ b/src/jupiterone/converters.test.ts
@@ -427,7 +427,7 @@ describe('createApplicationEntity', () => {
           },
         },
       ],
-      _type: 'crowdstrike_application',
+      _type: 'crowdstrike_detected_application',
       name: 'Windows Server 2016 1607',
       displayName: 'Windows Server 2016 1607',
       createdOn: undefined,

--- a/src/jupiterone/converters.ts
+++ b/src/jupiterone/converters.ts
@@ -5,7 +5,12 @@ import {
 } from '@jupiterone/integration-sdk-core';
 import { Entities } from '../steps/constants';
 
-import { Device, PreventionPolicy, Vulnerability } from '../crowdstrike/types';
+import {
+  Application,
+  Device,
+  PreventionPolicy,
+  Vulnerability,
+} from '../crowdstrike/types';
 
 function toCapitalCase(s: string): string {
   return s.toLowerCase().replace(/^\w/, (c) => c.toUpperCase());
@@ -197,6 +202,23 @@ export function createVulnerabilityEntity(source: Vulnerability) {
         exploitStatus: cve?.exploit_status,
         exprtRating: cve?.exprt_rating,
         // TODO: Consider additional properties: apps, remediation
+      },
+    },
+  });
+}
+
+export function createApplicationEntity(source: Application) {
+  return createIntegrationEntity({
+    entityData: {
+      source,
+      assign: {
+        _class: Entities.APPLICATION._class,
+        _type: Entities.APPLICATION._type,
+        _key: source.product_name_version.toLowerCase().replace(/\s/g, '-'),
+        name: source.product_name_version,
+        open: source.sub_status.toLowerCase() === 'open',
+        remediationIds: source.remediation?.ids,
+        evaluationLogicId: source.evaluation_logic.id,
       },
     },
   });

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -29,7 +29,8 @@ export const Entities: Record<
   | 'PROTECTION_SERVICE'
   | 'SENSOR'
   | 'PREVENTION_POLICY'
-  | 'VULNERABILITY',
+  | 'VULNERABILITY'
+  | 'APPLICATION',
   StepEntityMetadata
 > = {
   ACCOUNT: {
@@ -58,6 +59,12 @@ export const Entities: Record<
     _class: ['Finding'], // J1 data model considers CrowdStrike vulns as Findings. Note: this changes the billing of the entity
     partial: true,
   },
+  APPLICATION: {
+    resourceName: 'Application',
+    // this isn't really crowdstrike application, should we use mapped relationship and target some globally unique application instead?
+    _type: 'crowdstrike_application',
+    _class: ['Application'],
+  },
 };
 
 export const Relationships: Record<
@@ -65,7 +72,8 @@ export const Relationships: Record<
   | 'ACCOUNT_HAS_SENSOR'
   | 'PREVENTION_POLICY_ENFORCES_PROTECTION_SERVICE'
   | 'SENSOR_ASSIGNED_PREVENTION_POLICY'
-  | 'VULN_EXPLOITS_SENSOR',
+  | 'VULN_EXPLOITS_SENSOR'
+  | 'APP_HAS_VULN',
   StepRelationshipMetadata
 > = {
   ACCOUNT_HAS_PROTECTION_SERVICE: {
@@ -98,5 +106,11 @@ export const Relationships: Record<
     _class: RelationshipClass.EXPLOITS,
     targetType: Entities.SENSOR._type,
     partial: true,
+  },
+  APP_HAS_VULN: {
+    _type: 'crowdstrike_application_has_vulnerability',
+    sourceType: Entities.APPLICATION._type,
+    _class: RelationshipClass.HAS,
+    targetType: Entities.VULNERABILITY._type,
   },
 };

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -61,8 +61,7 @@ export const Entities: Record<
   },
   APPLICATION: {
     resourceName: 'Application',
-    // this isn't really crowdstrike application, should we use mapped relationship and target some globally unique application instead?
-    _type: 'crowdstrike_application',
+    _type: 'crowdstrike_detected_application',
     _class: ['Application'],
   },
 };
@@ -112,5 +111,6 @@ export const Relationships: Record<
     sourceType: Entities.APPLICATION._type,
     _class: RelationshipClass.HAS,
     targetType: Entities.VULNERABILITY._type,
+    partial: true,
   },
 };

--- a/src/steps/constants.ts
+++ b/src/steps/constants.ts
@@ -107,7 +107,7 @@ export const Relationships: Record<
     partial: true,
   },
   APP_HAS_VULN: {
-    _type: 'crowdstrike_application_has_vulnerability',
+    _type: 'crowdstrike_detected_application_has_vulnerability',
     sourceType: Entities.APPLICATION._type,
     _class: RelationshipClass.HAS,
     targetType: Entities.VULNERABILITY._type,


### PR DESCRIPTION
Some questions:

1) `crowdstrike_vulnerability` contains array of apps, thus we couldn't simply expose them as properties. The idea was to turn them into entities and make relationship between `crowdstrike_vulnerability` and `crowdstrike_application`.

2) "Windows Server 2016 1607" (for example) isn't really Crowdstrike application, but general application. Perhaps Crowdstrike shouldn't own this entity and its type shouldn't be `crowdstrike_application`? Perhaps a mapped relationship instead? Is there a generic globally unique application entity in the J1 system already?

3) app part contains the following info:

```
sub_status: 'open',
remediation: {
       ids: ['9497362a882d3be38b4505cbb9aa1e21'],
},
evaluation_logic: {
      id: 'eae54d591fe733398ac4aaa4652c8624',
},
```

it seems to describe the connection between app and vulnerability and the application entity properties might not be the best place for it - as it's not describing the app itself. Should this info leave on the edge?

### Added

The following entity is **now** created:

| Resources   | Entity `_type`            | Entity `_class` |
| ----------- | ------------------------- | --------------- |
| Application | `crowdstrike_application` | `Application`   |

The following relationship is **now** created:

| Source Entity `_type`     | Relationship `_class` | Target Entity `_type`       |
| ------------------------- | --------------------- | --------------------------- |
| `crowdstrike_application` | **HAS**               | `crowdstrike_vulnerability` |