### PR TITLE
NO-TICKET Change vuln timeframe to 30d

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- Changed ingesting vulnerabilities timeframe from 10 to 30 days.
+
 ## [3.2.0] - 2023-01-23
 
 ### Added

--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -15,10 +15,7 @@ import {
 import { IntegrationWarnEventName } from '@jupiterone/integration-sdk-core/dist/src/types/logger';
 import { createVulnerabilityFQLFilter } from './util';
 
-// maxDaysInPast is set to 10 days because most integrations will run at least once a week.
-// Additionally, at the time of this comment, we are just using the `created_timestamp`
-// as a filter, so the quantity of data can still be extremely large.
-const maxDaysInPast = 10;
+const maxDaysInPast = 30;
 
 async function fetchVulnerabilities({
   instance,


### PR DESCRIPTION
- Changed vulnerabilities ingestion timeframe from 10 to 30d as discussed in INT-6356