### PR TITLE
Update index.ts

### DIFF
--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -44,7 +44,11 @@ async function fetchVulnerabilities({
         limit: instance.config.vulnerabilitiesLimit ?? '400',
         filter,
         sort: `created_timestamp|desc`,
-        facet: 'cve',
+        facet: {
+           'cve',
+           'host_info',
+           'remediation',
+        },
       },
       callback: async (vulns) => {
         for (const vulnerability of vulns) {

--- a/src/steps/vulnerabilities/index.ts
+++ b/src/steps/vulnerabilities/index.ts
@@ -44,11 +44,7 @@ async function fetchVulnerabilities({
         limit: instance.config.vulnerabilitiesLimit ?? '400',
         filter,
         sort: `created_timestamp|desc`,
-        facet: {
-           'cve',
-           'host_info',
-           'remediation',
-        },
+        facet: ['cve', 'host_info','remediation'],
       },
       callback: async (vulns) => {
         for (const vulnerability of vulns) {


### PR DESCRIPTION
By default the CVE facet provides all the details about each vulnerability. The problem is there is no link of the CVE to the sensor. In addition to this the remediation details are missing. 

This pull request modifies the facet to include all three of the data outputs: cve, host_info, and remediation.