### PR TITLE
Changing when we authenticate

### DIFF
--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -401,8 +401,6 @@ export class FalconAPIClient {
     requestUrl: string,
     init: RequestInit,
   ): Promise<T> {
-
-
     /**
      * This is the logic to be retried in the case of an error.
      */

--- a/src/crowdstrike/FalconAPIClient.ts
+++ b/src/crowdstrike/FalconAPIClient.ts
@@ -401,12 +401,13 @@ export class FalconAPIClient {
     requestUrl: string,
     init: RequestInit,
   ): Promise<T> {
-    await this.authenticate();
+
 
     /**
      * This is the logic to be retried in the case of an error.
      */
     const requestAttempt = async () => {
+      await this.authenticate();
       const startTime = Date.now();
       const response = await fetch(requestUrl, {
         ...init,
@@ -431,7 +432,6 @@ export class FalconAPIClient {
           ? Number(response.headers.get('X-RateLimit-RetryAfter'))
           : undefined,
       };
-
       // Manually handle redirects.
       if ([301, 302, 308].includes(response.status)) {
         return this.handleRedirects(response, (redirectLocationUrl) => {
@@ -459,15 +459,6 @@ export class FalconAPIClient {
           statusText: response.statusText,
           endpoint: requestUrl,
         });
-      }
-      if (response.status == 400) {
-        const body = await response.text();
-        this.logger.info(
-          {
-            body,
-          },
-          '400 error response',
-        );
       }
       throw new IntegrationProviderAPIError({
         status: response.status,


### PR DESCRIPTION
We are getting 
<img width="690" alt="Screenshot 2023-07-03 at 11 44 30" src="https://github.com/JupiterOne/graph-crowdstrike/assets/79454854/12247a6c-bbc0-4ec5-9cb0-96925267e884">

<img width="735" alt="Screenshot 2023-07-03 at 11 44 49" src="https://github.com/JupiterOne/graph-crowdstrike/assets/79454854/37f08de1-1adb-4729-93f0-6526f65b7e5e">
So i moved the authenticate to inside the attempt tp=o avoid getting a malformed/invalid tokens. This should prevent cases when the token expires between the authentication and when the first call is actually made. 
It shouldn't be to time consuming to call authenticate each time since the method first checks if the token is invalid before actually re-validating.

I think this is a better approach than to re-authenticate once we get a 401, since if we do that, the this.rateLimitState variable would be changed to 15 requests per minute.

Maybe we are hitting 15 401 across all steps - all integrations (that share the same IP), and this promps the crowdstrike api to behave erratic.

Generally, we might want to consider making the client NOT a singleton. 